### PR TITLE
Support for ngDisabled

### DIFF
--- a/angular-ckeditor.js
+++ b/angular-ckeditor.js
@@ -47,9 +47,9 @@
             });
           });
 
-          controller.instance.setReadOnly(!! attrs.readonly);
-          attrs.$observe('readonly', function (readonly) {
-            controller.instance.setReadOnly(!! readonly);
+          controller.instance.setReadOnly(!! $parse(attrs.ngDisabled)(scope));
+          scope.$watch(attrs.ngDisabled, function () {
+            controller.instance.setReadOnly(!! $parse(attrs.ngDisabled)(scope));
           });
 
           // Defer the ready handler calling to ensure that the editor is

--- a/angular-ckeditor.min.js
+++ b/angular-ckeditor.min.js
@@ -12,7 +12,7 @@ var g=f[0],h=f[1];
 // Initialize the editor content when it is ready.
 g.ready().then(function(){
 // Sync view on specific events.
-["dataReady","change","blur","saveSnapshot"].forEach(function(a){g.onCKEvent(a,function(){h.$setViewValue(g.instance.getData()||"")})}),g.instance.setReadOnly(!!e.readonly),e.$observe("readonly",function(a){g.instance.setReadOnly(!!a)}),
+["dataReady","change","blur","saveSnapshot"].forEach(function(a){g.onCKEvent(a,function(){h.$setViewValue(g.instance.getData()||"")})}),g.instance.setReadOnly(!!a(e.ngDisabled)(b)),b.$watch(e.ngDisabled,function(){g.instance.setReadOnly(!!a(e.ngDisabled)(b))}),
 // Defer the ready handler calling to ensure that the editor is
 // completely ready and populated with data.
 d(function(){a(e.ready)(b)})}),


### PR DESCRIPTION
This directive does have attribute `readonly` available for disabling the editor, but it has a bug when using expressions: the interpolated expression value is read as a string in the directive and so always evaluates as truthy. I replaced the `readonly` attribute with support for `ng-disabled` and fixed the expression bug, so that the boolean value of the expression is used in the `setReadOnly()` function.

`<div ckeditor ng-model="myEditor" ng-disabled="myEditorDisabled"></div>`