### PR TITLE
Fix to allow Angular expressions in readonly property

### DIFF
--- a/angular-ckeditor.js
+++ b/angular-ckeditor.js
@@ -47,9 +47,9 @@
             });
           });
 
-          controller.instance.setReadOnly(!! attrs.readonly);
-          attrs.$observe('readonly', function (readonly) {
-            controller.instance.setReadOnly(!! readonly);
+          controller.instance.setReadOnly(!! $parse(attrs.readonly)(scope));
+          scope.$watch(attrs.readonly, function () {
+            controller.instance.setReadOnly(!! $parse(attrs.readonly)(scope));
           });
 
           // Defer the ready handler calling to ensure that the editor is

--- a/angular-ckeditor.min.js
+++ b/angular-ckeditor.min.js
@@ -12,7 +12,7 @@ var g=f[0],h=f[1];
 // Initialize the editor content when it is ready.
 g.ready().then(function(){
 // Sync view on specific events.
-["dataReady","change","blur","saveSnapshot"].forEach(function(a){g.onCKEvent(a,function(){h.$setViewValue(g.instance.getData()||"")})}),g.instance.setReadOnly(!!e.readonly),e.$observe("readonly",function(a){g.instance.setReadOnly(!!a)}),
+["dataReady","change","blur","saveSnapshot"].forEach(function(a){g.onCKEvent(a,function(){h.$setViewValue(g.instance.getData()||"")})}),g.instance.setReadOnly(!!a(e.readonly)(b)),b.$watch(e.readonly,function(){g.instance.setReadOnly(!!a(e.readonly)(b))}),
 // Defer the ready handler calling to ensure that the editor is
 // completely ready and populated with data.
 d(function(){a(e.ready)(b)})}),


### PR DESCRIPTION
This directive currently has a readonly attribute you can set with an interpolated expression, but it is evaluated as a string value in the directive which ends up always being truthy in the 'setReadOnly()' function. I changed it to use `$parse`.